### PR TITLE
Fix user enumeration vulnerability

### DIFF
--- a/pkg/authentication/authenticator.go
+++ b/pkg/authentication/authenticator.go
@@ -1,8 +1,6 @@
 package authentication
 
 import (
-	"fmt"
-
 	"github.com/mmcdole/viking-ftpd/pkg/logging"
 	"github.com/mmcdole/viking-ftpd/pkg/users"
 )
@@ -22,26 +20,42 @@ func NewAuthenticator(source users.Source, verifier PasswordHashVerifier) *Authe
 }
 
 // Authenticate verifies a username and password combination.
-// Returns ErrInvalidUsername if user not found, ErrInvalidPassword if password incorrect.
+// Returns ErrInvalidCredentials for any authentication failure to prevent user enumeration.
+// This implements constant-time authentication by always performing password verification.
 func (a *Authenticator) Authenticate(username, password string) (*users.User, error) {
 	logging.App.Debug("Authentication attempt", "user", username)
 	
 	user, err := a.source.LoadUser(username)
-	if err != nil {
+	var userExists bool = err == nil
+	var passwordHash string
+	
+	if userExists {
+		passwordHash = user.PasswordHash
+		logging.App.Debug("Found user, verifying password", "user", username, "hash", passwordHash)
+	} else {
+		// Use a dummy hash to maintain constant timing behavior
+		// This is a bcrypt hash of "dummy" to ensure consistent verification time
+		passwordHash = "$2a$10$N9qo8uLOickgx2ZMRZoMye1NW8k3xPGLhpMeE.f0aK5bPHQu3CcI2"
 		if err == users.ErrUserNotFound {
 			logging.App.Debug("User not found", "user", username)
-			return nil, ErrInvalidUsername
+		} else {
+			logging.App.Debug("Error loading user", "user", username, "error", err)
 		}
-		logging.App.Debug("Error loading user", "user", username, "error", err)
-		return nil, fmt.Errorf("loading user: %w", err)
 	}
 
-	logging.App.Debug("Found user, verifying password", "user", username, "hash", user.PasswordHash)
-	if err := a.verifier.VerifyPassword(password, user.PasswordHash); err != nil {
-		logging.App.Debug("Password verification failed", "user", username, "error", err)
-		return nil, ErrInvalidPassword
+	// Always perform password verification to prevent timing attacks
+	passwordErr := a.verifier.VerifyPassword(password, passwordHash)
+	
+	// Only return success if user exists AND password is correct
+	if userExists && passwordErr == nil {
+		logging.App.Debug("Authentication successful", "user", username)
+		return user, nil
 	}
-
-	logging.App.Debug("Authentication successful", "user", username)
-	return user, nil
+	
+	// Log specific failure reason for debugging, but return generic error
+	if userExists {
+		logging.App.Debug("Password verification failed", "user", username, "error", passwordErr)
+	}
+	
+	return nil, ErrInvalidCredentials
 }

--- a/pkg/authentication/authenticator_test.go
+++ b/pkg/authentication/authenticator_test.go
@@ -78,13 +78,19 @@ func TestAuthenticator_Authenticate(t *testing.T) {
 			name:     "invalid password",
 			username: "user1",
 			password: "wrongpass",
-			wantErr:  ErrInvalidPassword,
+			wantErr:  ErrInvalidCredentials,
 		},
 		{
 			name:     "user not found",
 			username: "nonexistent",
 			password: "testpass123",
-			wantErr:  ErrInvalidUsername,
+			wantErr:  ErrInvalidCredentials,
+		},
+		{
+			name:     "user not found with wrong password",
+			username: "nonexistent",
+			password: "wrongpass",
+			wantErr:  ErrInvalidCredentials,
 		},
 	}
 

--- a/pkg/ftpserver/server.go
+++ b/pkg/ftpserver/server.go
@@ -124,7 +124,7 @@ func (d *ftpDriver) AuthUser(cc ftpserverlib.ClientContext, user, pass string) (
 	_, err := d.server.authenticator.Authenticate(user, pass)
 	if err != nil {
 		logging.Access.LogAuth("login", user, "failed", "error", err, "client_ip", cc.RemoteAddr().String())
-		return nil, fmt.Errorf("authentication failed: %w", err)
+		return nil, fmt.Errorf("authentication failed")
 	}
 
 	// Create filesystem with root already handled


### PR DESCRIPTION
## Summary
- Replace specific authentication error messages with generic responses
- Implement constant-time authentication to prevent timing attacks  
- Prevent username enumeration while preserving internal logging

## Test plan
- [x] Authentication tests pass
- [x] Invalid usernames and passwords return same error
- [x] Build succeeds