### PR TITLE
fix: Disable active FTP mode for better NAT/firewall compatibility

### DIFF
--- a/pkg/ftpserver/server.go
+++ b/pkg/ftpserver/server.go
@@ -84,7 +84,8 @@ func (d *ftpDriver) GetSettings() (*ftpserverlib.Settings, error) {
 			Start: d.server.config.PasvPortRange[0],
 			End:   d.server.config.PasvPortRange[1],
 		},
-		TLSRequired: ftpserverlib.ClearOrEncrypted,
+		TLSRequired:       ftpserverlib.ClearOrEncrypted,
+		DisableActiveMode: true,
 	}
 
 	if d.server.config.PasvAddress != "" {


### PR DESCRIPTION
Active mode FTP has compatibility issues with clients behind NAT/firewalls and SSH tunneled connections attempting LPRT commands. Passive mode is the industry standard and provides better compatibility across different network configurations.