### PR TITLE
feat(monitoring): add status file monitoring for MUD health checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,21 @@ The server directly reads MUD data files:
 3. **Authorization**: File operation requested → path normalized → access tree traversed from root to target → permissions resolved with inheritance → operation allowed/denied
 4. **File Access**: All file operations are jailed within `ftp_root_dir`. User home directory follows `home_pattern` (e.g., `players/{username}`).
 
+### Status File Monitoring
+
+Optional health monitoring feature that writes status files for MUD integration:
+
+**Files created** (in `status_dir` if configured):
+- `last_start` - Written once at startup with timestamp, PID, and version
+- `running` - Updated every 10 seconds with live metrics (connections, memory, goroutines, uptime)
+- `last_stop` - Written on graceful shutdown with reason and uptime
+
+**Crash detection**: MUD can detect daemon crashes by checking if `running` is stale (>60s old) without corresponding `last_stop` update.
+
+**File format**: Simple `key: value` pairs for easy LPC parsing.
+
+**Signal handling**: Daemon responds to SIGTERM/SIGINT with graceful shutdown, writing `last_stop` with appropriate reason.
+
 ### Security Considerations
 
 - **Timing attack protection**: Authentication always performs hash verification even for non-existent users

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Create a configuration file in JSON format. Example:
     "access_cache_time": 60,
     "access_log_path": "/mud/lib/log/vkftpd-access.log",
     "app_log_path": "/mud/lib/log/vkftpd-app.log",
-    "log_level": "info"
+    "log_level": "info",
+    "status_dir": "/mud/lib/sys/ftp"
 }
 ```
 
@@ -76,6 +77,42 @@ If TLS certificate and key files are provided, the server will support both FTP 
 - `access_log_path`: Path to access log file (optional)
 - `app_log_path`: Path to application log file (optional)
 - `log_level`: Log level (debug, info, warn, error, panic) (default: info)
+
+### Status Monitoring
+- `status_dir`: Directory for status files (optional). When configured, the daemon writes health monitoring files that the MUD can read to track daemon status.
+
+#### Status Files
+
+When `status_dir` is configured, the daemon creates three files for monitoring:
+
+**`last_start`** - Written once at startup:
+```
+timestamp_unix: 1727888400
+timestamp_human: Thu Oct 02 12:00:00 2025
+pid: 29481
+version: v1.0.10
+```
+
+**`running`** - Updated every 10 seconds with live metrics:
+```
+timestamp_unix: 1727889305
+uptime_seconds: 905
+active_connections: 12
+memory_alloc_mb: 45
+memory_sys_mb: 72
+goroutines: 23
+gc_cpu_fraction: 0.0011
+```
+
+**`last_stop`** - Written only on graceful shutdown:
+```
+timestamp_unix: 1727892000
+timestamp_human: Thu Oct 02 12:40:00 2025
+reason: signal_SIGTERM
+uptime_seconds: 3600
+```
+
+The MUD can monitor daemon health by checking if `running` is recent (timestamp < 60 seconds old). If the daemon crashes, `last_stop` won't be updated, allowing crash detection.
 
 ## Package Overview
 

--- a/README.md
+++ b/README.md
@@ -79,40 +79,7 @@ If TLS certificate and key files are provided, the server will support both FTP 
 - `log_level`: Log level (debug, info, warn, error, panic) (default: info)
 
 ### Status Monitoring
-- `status_dir`: Directory for status files (optional). When configured, the daemon writes health monitoring files that the MUD can read to track daemon status.
-
-#### Status Files
-
-When `status_dir` is configured, the daemon creates three files for monitoring:
-
-**`last_start`** - Written once at startup:
-```
-timestamp_unix: 1727888400
-timestamp_human: Thu Oct 02 12:00:00 2025
-pid: 29481
-version: v1.0.10
-```
-
-**`running`** - Updated every 10 seconds with live metrics:
-```
-timestamp_unix: 1727889305
-uptime_seconds: 905
-active_connections: 12
-memory_alloc_mb: 45
-memory_sys_mb: 72
-goroutines: 23
-gc_cpu_fraction: 0.0011
-```
-
-**`last_stop`** - Written only on graceful shutdown:
-```
-timestamp_unix: 1727892000
-timestamp_human: Thu Oct 02 12:40:00 2025
-reason: signal_SIGTERM
-uptime_seconds: 3600
-```
-
-The MUD can monitor daemon health by checking if `running` is recent (timestamp < 60 seconds old). If the daemon crashes, `last_stop` won't be updated, allowing crash detection.
+- `status_dir`: Directory for status files (optional). When configured, writes three monitoring files: `last_start` (startup info), `running` (live metrics updated every 10s), and `last_stop` (shutdown reason). The MUD can detect crashes by checking if `running` is stale (>60s old) without a corresponding `last_stop` update.
 
 ## Package Overview
 

--- a/cmd/vkftpd/config.go
+++ b/cmd/vkftpd/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	AccessLogPath string `json:"access_log_path"` // Path to access log file
 	AppLogPath    string `json:"app_log_path"`    // Path to application log file
 	LogLevel      string `json:"log_level"`       // Log level (debug, info, warn, error, panic)
+
+	// Status monitoring (optional)
+	StatusDir string `json:"status_dir"` // Directory for status files (last_start, running, last_stop)
 }
 
 // LoadConfig loads configuration from a JSON file
@@ -69,6 +72,11 @@ func LoadConfig(path string, config *Config) error {
 	}
 	if config.AppLogPath != "" && !filepath.IsAbs(config.AppLogPath) {
 		config.AppLogPath = filepath.Join(configDir, config.AppLogPath)
+	}
+
+	// Convert status directory to absolute if specified and not absolute
+	if config.StatusDir != "" && !filepath.IsAbs(config.StatusDir) {
+		config.StatusDir = filepath.Join(configDir, config.StatusDir)
 	}
 
 	// Convert TLS paths to absolute if specified and not absolute

--- a/cmd/vkftpd/main.go
+++ b/cmd/vkftpd/main.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/mmcdole/viking-ftpd/pkg/authentication"
 	"github.com/mmcdole/viking-ftpd/pkg/authorization"
 	"github.com/mmcdole/viking-ftpd/pkg/ftpserver"
 	"github.com/mmcdole/viking-ftpd/pkg/logging"
+	"github.com/mmcdole/viking-ftpd/pkg/status"
 	"github.com/mmcdole/viking-ftpd/pkg/users"
 	"github.com/spf13/cobra"
 )
@@ -111,8 +116,87 @@ Configuration file must be in JSON format with the following structure:
 			return fmt.Errorf("failed to create FTP server: %w", err)
 		}
 
+		// Initialize status writer if configured
+		var statusWriter *status.Writer
+		if config.StatusDir != "" {
+			statusWriter, err = status.New(config.StatusDir, 10*time.Second, version)
+			if err != nil {
+				return fmt.Errorf("failed to create status writer: %w", err)
+			}
+
+			// Set server as metrics provider
+			statusWriter.SetMetricsProvider(server)
+
+			// Write startup file
+			if err := statusWriter.WriteStartFile(); err != nil {
+				return fmt.Errorf("failed to write start file: %w", err)
+			}
+
+			// Start heartbeat
+			statusWriter.StartHeartbeat()
+
+			// Defer cleanup for graceful shutdown
+			defer func() {
+				statusWriter.Stop()
+				uptime := time.Since(server.GetStartTime())
+				if err := statusWriter.WriteStopFile("signal_SIGTERM", uptime); err != nil {
+					logging.App.Error("Failed to write stop file", "error", err)
+				}
+			}()
+		}
+
 		logging.App.Info("Starting VikingMUD FTP Server", "version", version, "listen_addr", config.ListenAddr, "port", config.Port)
-		return server.ListenAndServe()
+
+		// Set up signal handling for graceful shutdown
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+		// Start server in goroutine
+		serverErr := make(chan error, 1)
+		go func() {
+			serverErr <- server.ListenAndServe()
+		}()
+
+		// Wait for signal or server error
+		select {
+		case err := <-serverErr:
+			if err != nil {
+				logging.App.Error("Server error", "error", err)
+				return fmt.Errorf("server error: %w", err)
+			}
+		case sig := <-sigChan:
+			logging.App.Info("Received signal, shutting down gracefully", "signal", sig)
+
+			// Update stop file reason if we have status writer
+			if statusWriter != nil {
+				statusWriter.Stop()
+				reason := fmt.Sprintf("signal_%s", sig)
+				uptime := time.Since(server.GetStartTime())
+				if err := statusWriter.WriteStopFile(reason, uptime); err != nil {
+					logging.App.Error("Failed to write stop file", "error", err)
+				}
+			}
+
+			// Create a context with timeout for graceful shutdown
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			// Stop accepting new connections and wait for existing ones
+			if err := server.Stop(); err != nil {
+				logging.App.Error("Error stopping server", "error", err)
+				return fmt.Errorf("error stopping server: %w", err)
+			}
+
+			// Wait a bit for connections to clean up
+			select {
+			case <-ctx.Done():
+				logging.App.Warn("Shutdown timeout exceeded, forcing exit")
+			case <-time.After(2 * time.Second):
+				logging.App.Info("Graceful shutdown complete")
+			}
+		}
+
+		return nil
 	},
 }
 

--- a/pkg/status/writer.go
+++ b/pkg/status/writer.go
@@ -1,0 +1,199 @@
+package status
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/mmcdole/viking-ftpd/pkg/logging"
+)
+
+// MetricsProvider defines the interface for collecting runtime metrics
+type MetricsProvider interface {
+	GetActiveConnections() int32
+	GetStartTime() time.Time
+}
+
+// Writer manages status files for daemon health monitoring
+type Writer struct {
+	dir             string
+	updateInterval  time.Duration
+	pid             int
+	version         string
+	metricsProvider MetricsProvider
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// New creates a new status Writer
+func New(dir string, updateInterval time.Duration, version string) (*Writer, error) {
+	// Ensure directory exists
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create status directory: %w", err)
+	}
+
+	return &Writer{
+		dir:            dir,
+		updateInterval: updateInterval,
+		pid:            os.Getpid(),
+		version:        version,
+		stopCh:         make(chan struct{}),
+	}, nil
+}
+
+// SetMetricsProvider sets the provider for runtime metrics
+func (w *Writer) SetMetricsProvider(provider MetricsProvider) {
+	w.metricsProvider = provider
+}
+
+// WriteStartFile writes the last_start file with startup information
+func (w *Writer) WriteStartFile() error {
+	now := time.Now()
+	content := fmt.Sprintf(`timestamp_unix: %d
+timestamp_human: %s
+pid: %d
+version: %s
+`,
+		now.Unix(),
+		now.Format("Mon Jan 02 15:04:05 2006"),
+		w.pid,
+		w.version,
+	)
+
+	path := filepath.Join(w.dir, "last_start")
+	if err := w.atomicWrite(path, []byte(content)); err != nil {
+		return fmt.Errorf("failed to write last_start: %w", err)
+	}
+
+	logging.App.Info("Wrote status file", "file", "last_start")
+	return nil
+}
+
+// WriteStopFile writes the last_stop file with shutdown information
+func (w *Writer) WriteStopFile(reason string, uptime time.Duration) error {
+	now := time.Now()
+	content := fmt.Sprintf(`timestamp_unix: %d
+timestamp_human: %s
+reason: %s
+uptime_seconds: %d
+`,
+		now.Unix(),
+		now.Format("Mon Jan 02 15:04:05 2006"),
+		reason,
+		int64(uptime.Seconds()),
+	)
+
+	path := filepath.Join(w.dir, "last_stop")
+	if err := w.atomicWrite(path, []byte(content)); err != nil {
+		return fmt.Errorf("failed to write last_stop: %w", err)
+	}
+
+	logging.App.Info("Wrote status file", "file", "last_stop", "reason", reason)
+	return nil
+}
+
+// StartHeartbeat starts a goroutine that periodically updates the running file
+func (w *Writer) StartHeartbeat() {
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+
+		ticker := time.NewTicker(w.updateInterval)
+		defer ticker.Stop()
+
+		// Write immediately on start
+		if err := w.writeRunningFile(); err != nil {
+			logging.App.Error("Failed to write running file", "error", err)
+		}
+
+		for {
+			select {
+			case <-ticker.C:
+				if err := w.writeRunningFile(); err != nil {
+					logging.App.Error("Failed to write running file", "error", err)
+				}
+			case <-w.stopCh:
+				return
+			}
+		}
+	}()
+
+	logging.App.Info("Started status heartbeat", "interval", w.updateInterval)
+}
+
+// Stop stops the heartbeat goroutine
+func (w *Writer) Stop() {
+	close(w.stopCh)
+	w.wg.Wait()
+	logging.App.Info("Stopped status heartbeat")
+}
+
+// writeRunningFile writes the current runtime status to the running file
+func (w *Writer) writeRunningFile() error {
+	now := time.Now()
+
+	var startTime time.Time
+	var activeConnections int32
+
+	if w.metricsProvider != nil {
+		startTime = w.metricsProvider.GetStartTime()
+		activeConnections = w.metricsProvider.GetActiveConnections()
+	}
+
+	uptime := int64(0)
+	if !startTime.IsZero() {
+		uptime = int64(now.Sub(startTime).Seconds())
+	}
+
+	// Collect memory statistics
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	content := fmt.Sprintf(`timestamp_unix: %d
+uptime_seconds: %d
+active_connections: %d
+memory_alloc_mb: %d
+memory_sys_mb: %d
+goroutines: %d
+gc_cpu_fraction: %.6f
+`,
+		now.Unix(),
+		uptime,
+		activeConnections,
+		memStats.Alloc/1024/1024,
+		memStats.Sys/1024/1024,
+		runtime.NumGoroutine(),
+		memStats.GCCPUFraction,
+	)
+
+	path := filepath.Join(w.dir, "running")
+	if err := w.atomicWrite(path, []byte(content)); err != nil {
+		return fmt.Errorf("failed to write running: %w", err)
+	}
+
+	logging.App.Debug("Updated running file", "active_connections", activeConnections, "goroutines", runtime.NumGoroutine())
+	return nil
+}
+
+// atomicWrite writes content to a file atomically by writing to a temp file
+// and then renaming it. This prevents readers from seeing partial writes.
+func (w *Writer) atomicWrite(path string, content []byte) error {
+	tmpPath := path + ".tmp"
+
+	// Write to temp file
+	if err := os.WriteFile(tmpPath, content, 0644); err != nil {
+		return err
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath) // Clean up temp file on error
+		return err
+	}
+
+	return nil
+}

--- a/pkg/status/writer_test.go
+++ b/pkg/status/writer_test.go
@@ -1,0 +1,310 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockMetricsProvider implements MetricsProvider for testing
+type mockMetricsProvider struct {
+	activeConnections int32
+	startTime         time.Time
+}
+
+func (m *mockMetricsProvider) GetActiveConnections() int32 {
+	return m.activeConnections
+}
+
+func (m *mockMetricsProvider) GetStartTime() time.Time {
+	return m.startTime
+}
+
+func TestNew(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(tmpDir, 10*time.Second, "v1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	if w.dir != tmpDir {
+		t.Errorf("Expected dir %s, got %s", tmpDir, w.dir)
+	}
+
+	if w.version != "v1.0.0" {
+		t.Errorf("Expected version v1.0.0, got %s", w.version)
+	}
+
+	if w.pid == 0 {
+		t.Error("Expected non-zero PID")
+	}
+
+	// Check that directory was created
+	if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
+		t.Error("Status directory was not created")
+	}
+}
+
+func TestWriteStartFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(tmpDir, 10*time.Second, "v1.2.3")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	if err := w.WriteStartFile(); err != nil {
+		t.Fatalf("Failed to write start file: %v", err)
+	}
+
+	// Read and verify contents
+	path := filepath.Join(tmpDir, "last_start")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read start file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Check for required fields
+	requiredFields := []string{
+		"timestamp_unix:",
+		"timestamp_human:",
+		"pid:",
+		"version: v1.2.3",
+	}
+
+	for _, field := range requiredFields {
+		if !strings.Contains(contentStr, field) {
+			t.Errorf("Start file missing field: %s", field)
+		}
+	}
+
+	// Check file permissions
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Failed to stat file: %v", err)
+	}
+
+	if info.Mode().Perm() != 0644 {
+		t.Errorf("Expected file permissions 0644, got %o", info.Mode().Perm())
+	}
+}
+
+func TestWriteStopFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(tmpDir, 10*time.Second, "v1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	uptime := 3600 * time.Second
+	if err := w.WriteStopFile("signal_SIGTERM", uptime); err != nil {
+		t.Fatalf("Failed to write stop file: %v", err)
+	}
+
+	// Read and verify contents
+	path := filepath.Join(tmpDir, "last_stop")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read stop file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Check for required fields
+	requiredFields := []string{
+		"timestamp_unix:",
+		"timestamp_human:",
+		"reason: signal_SIGTERM",
+		"uptime_seconds: 3600",
+	}
+
+	for _, field := range requiredFields {
+		if !strings.Contains(contentStr, field) {
+			t.Errorf("Stop file missing field: %s", field)
+		}
+	}
+}
+
+func TestWriteRunningFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(tmpDir, 10*time.Second, "v1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	// Set up mock metrics provider
+	mock := &mockMetricsProvider{
+		activeConnections: 5,
+		startTime:         time.Now().Add(-1 * time.Hour),
+	}
+	w.SetMetricsProvider(mock)
+
+	if err := w.writeRunningFile(); err != nil {
+		t.Fatalf("Failed to write running file: %v", err)
+	}
+
+	// Read and verify contents
+	path := filepath.Join(tmpDir, "running")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read running file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Check for required fields
+	requiredFields := []string{
+		"timestamp_unix:",
+		"uptime_seconds:",
+		"active_connections: 5",
+		"memory_alloc_mb:",
+		"memory_sys_mb:",
+		"goroutines:",
+		"gc_cpu_fraction:",
+	}
+
+	for _, field := range requiredFields {
+		if !strings.Contains(contentStr, field) {
+			t.Errorf("Running file missing field: %s", field)
+		}
+	}
+
+	// Verify uptime is approximately 1 hour (3600 seconds)
+	if !strings.Contains(contentStr, "uptime_seconds: 36") {
+		t.Error("Expected uptime to be around 3600 seconds")
+	}
+}
+
+func TestHeartbeat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Use a short interval for testing
+	w, err := New(tmpDir, 100*time.Millisecond, "v1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	mock := &mockMetricsProvider{
+		activeConnections: 3,
+		startTime:         time.Now(),
+	}
+	w.SetMetricsProvider(mock)
+
+	// Start heartbeat
+	w.StartHeartbeat()
+
+	// Wait for initial write
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify file was created
+	path := filepath.Join(tmpDir, "running")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("Running file was not created by heartbeat")
+	}
+
+	// Read initial timestamp
+	content1, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read running file: %v", err)
+	}
+
+	// Wait long enough for timestamp to change (> 1 second)
+	time.Sleep(1200 * time.Millisecond)
+
+	// Read updated timestamp
+	content2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read running file after update: %v", err)
+	}
+
+	// Verify that the file was updated (timestamps should be different)
+	if string(content1) == string(content2) {
+		t.Error("Running file was not updated by heartbeat")
+	}
+
+	// Stop heartbeat
+	w.Stop()
+
+	// Wait a bit to ensure no more updates
+	time.Sleep(150 * time.Millisecond)
+
+	// Verify that heartbeat stopped (file should not be updated anymore)
+	content3, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read running file after stop: %v", err)
+	}
+
+	if string(content2) != string(content3) {
+		t.Error("Running file was updated after heartbeat was stopped")
+	}
+}
+
+func TestAtomicWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(tmpDir, 10*time.Second, "v1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "testfile")
+	content := []byte("test content\n")
+
+	if err := w.atomicWrite(path, content); err != nil {
+		t.Fatalf("Failed to atomically write file: %v", err)
+	}
+
+	// Verify content
+	readContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	if string(readContent) != string(content) {
+		t.Errorf("Expected content %q, got %q", content, readContent)
+	}
+
+	// Verify temp file was removed
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Error("Temporary file was not removed")
+	}
+}
+
+func TestWithoutMetricsProvider(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	w, err := New(tmpDir, 10*time.Second, "v1.0.0")
+	if err != nil {
+		t.Fatalf("Failed to create writer: %v", err)
+	}
+
+	// Don't set metrics provider - should still work with zero values
+	if err := w.writeRunningFile(); err != nil {
+		t.Fatalf("Failed to write running file without metrics provider: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "running")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read running file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Should have zero values for connection count and uptime
+	if !strings.Contains(contentStr, "active_connections: 0") {
+		t.Error("Expected active_connections to be 0 without metrics provider")
+	}
+
+	if !strings.Contains(contentStr, "uptime_seconds: 0") {
+		t.Error("Expected uptime_seconds to be 0 without metrics provider")
+	}
+}


### PR DESCRIPTION
Implements health monitoring feature that writes status files for MUD to track daemon state. This allows the MUD to monitor FTP daemon health from within LPC code.

New Features:
- Status file writer with atomic writes and periodic updates
- Three status files: last_start, running, last_stop
- Graceful shutdown with SIGTERM/SIGINT signal handling
- Active connection tracking across FTP sessions
- Runtime metrics: memory usage, goroutine count, uptime, connections

Status Files:
- last_start: Written once at startup with PID, version, timestamp
- running: Updated every 10s with live metrics (connections, memory, etc)
- last_stop: Written on graceful shutdown with reason and uptime

Crash Detection:
MUD can detect crashes by checking if running file is stale (>60s) without corresponding last_stop update.

Implementation:
- pkg/status: New package for status file management
- pkg/ftpserver: Added connection tracking with atomic counters
- cmd/vkftpd: Signal handling and graceful shutdown orchestration
- Config: New optional status_dir field

File Format:
Simple key: value pairs for easy parsing in LPC code.