### PR TITLE
fix(authorization): synchronize tree cache reads in ResolvePermission

### DIFF
--- a/pkg/authorization/authorizer.go
+++ b/pkg/authorization/authorizer.go
@@ -45,6 +45,13 @@ func (a *Authorizer) ResolvePermission(username string, filepath string) Permiss
 		return Revoked
 	}
 
+	// Snapshot the tree map under the read lock. refreshCache replaces the
+	// map wholesale rather than mutating it, so the captured reference is a
+	// stable, immutable view even if a concurrent refresh swaps in a new map.
+	a.mu.RLock()
+	trees := a.trees
+	a.mu.RUnlock()
+
 	// Clean the path and split into parts
 	parts := strings.Split(path.Clean(filepath), "/")
 	if len(parts) > 0 && parts[0] == "" {
@@ -62,7 +69,7 @@ func (a *Authorizer) ResolvePermission(username string, filepath string) Permiss
 	}
 
 	// Check user's direct permissions
-	if tree, ok := a.trees[username]; ok {
+	if tree, ok := trees[username]; ok {
 		perm := a.resolveNodePermission(tree.Root, parts)
 		if perm != Revoked {
 			logging.App.Debug("Resolved direct permission", "user", username, "path", filepath, "permission", perm)
@@ -72,7 +79,7 @@ func (a *Authorizer) ResolvePermission(username string, filepath string) Permiss
 
 	// Check all group permissions (both explicit and implicit)
 	for _, group := range a.ResolveGroups(username) {
-		if tree, ok := a.trees[group]; ok {
+		if tree, ok := trees[group]; ok {
 			perm := a.resolveNodePermission(tree.Root, parts)
 			if perm != Revoked {
 				logging.App.Debug("Resolved group permission", "user", username, "group", group, "path", filepath, "permission", perm)
@@ -82,7 +89,7 @@ func (a *Authorizer) ResolvePermission(username string, filepath string) Permiss
 	}
 
 	// Finally check default permissions
-	if tree, ok := a.trees["*"]; ok {
+	if tree, ok := trees["*"]; ok {
 		perm := a.resolveNodePermission(tree.Root, parts)
 		logging.App.Debug("Using default permission", "user", username, "path", filepath, "permission", perm)
 		return perm

--- a/pkg/authorization/authorizer_race_test.go
+++ b/pkg/authorization/authorizer_race_test.go
@@ -1,0 +1,66 @@
+package authorization
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestResolvePermissionConcurrentWithCacheRefresh drives ResolvePermission from
+// many goroutines while the cache continuously refreshes (cacheDuration 0 forces
+// a map swap on nearly every call). Run under -race, it fails if ResolvePermission
+// reads the tree map without synchronizing against refreshCache's replacement.
+func TestResolvePermissionConcurrentWithCacheRefresh(t *testing.T) {
+	source := newMockUserSource()
+	source.addUser("wizard1", 31)
+	source.addUser("arch1", 45)
+
+	auth := NewAuthorizer(newMockAccessSource(productionTree()), source, 0)
+
+	const goroutines = 16
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			users := []string{"wizard1", "arch1", "nobody"}
+			paths := []string{"/players/wizard1/file.c", "/d/Realm/room.c", "/tmp/x", "/"}
+			for i := 0; i < iterations; i++ {
+				u := users[(id+i)%len(users)]
+				p := paths[i%len(paths)]
+				auth.CanRead(u, p)
+				auth.CanWrite(u, p)
+				auth.ResolveGroups(u)
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestResolvePermissionSnapshotStability confirms a caller reading during a
+// refresh still gets a coherent answer (no panic/torn map), exercised with a
+// tight refresh interval and a concurrent forced refresh.
+func TestResolvePermissionSnapshotStability(t *testing.T) {
+	source := newMockUserSource()
+	source.addUser("wizard1", 31)
+
+	auth := NewAuthorizer(newMockAccessSource(productionTree()), source, time.Nanosecond)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = auth.refreshCache()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			auth.CanRead("wizard1", "/players/wizard1/x")
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #15

ResolvePermission read the cached access-tree map for the direct, group, and default lookups without holding the mutex, while refreshCache replaces that map under the write lock. Two requests crossing an access-cache expiry were a data race on every authorization decision, in both the FTP and SFTP servers.

The fix snapshots the map reference under the read lock once at the top of ResolvePermission and uses the local for all three lookups. refreshCache replaces the map wholesale rather than mutating it in place, so a captured reference is a stable, immutable view even if a refresh swaps in a new map mid-call.

Includes a test that drives concurrent CanRead/CanWrite/ResolveGroups across a forced cache refresh; it reports DATA RACE under `-race` without the fix and passes with it. Full suite passes under `go test -race ./...`.

https://claude.ai/code/session_01LVejDJLbKQar4kPkaAsPrF