### PR TITLE
fix(ftpserver): remove dead methods, clamp upload perms, add audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Notes:
 - Only the `sftp` subsystem is served. Shell, exec, and port-forwarding requests are refused, so `ssh` gives no shell and `scp` (which uses exec) does not work — use `sftp`/SFTP-capable clients.
 - SFTP operations appear in the access log with the same `op=`/`status=` vocabulary as FTP (plus a `setstat` op for attribute changes); connect, disconnect, and login lines carry an extra `protocol=sftp` field. SFTP has no `chdir` operation (directory changes are client-side in the protocol).
 - Symlink and hardlink creation, and readlink, are refused. Client-requested ownership changes (chown) are accepted but ignored — there is no owner concept in the MUD's permission model.
-- `max_connections` is currently enforced for SFTP connections only; the FTP server does not yet apply it.
+- `max_connections` is enforced for both FTP and SFTP connections (each protocol counts its own connections against the limit).
 
 ### Caching and Logging
 - `character_cache_time`: How long to cache character data in seconds (default: 60)

--- a/cmd/vkftpd/config.go
+++ b/cmd/vkftpd/config.go
@@ -40,11 +40,11 @@ type Config struct {
 	AccessCacheTime    int `json:"access_cache_time"`    // How long to cache access data (seconds)
 
 	// Logging settings
-	AccessLogPath     string `json:"access_log_path"`      // Path to access log file
-	AppLogPath        string `json:"app_log_path"`         // Path to application log file
-	LogLevel          string `json:"log_level"`            // Log level (debug, info, warn, error, panic)
-	MaxLogSize        int    `json:"max_log_size"`         // Maximum log size in bytes before rotation
-	LogVerifyInterval int    `json:"log_verify_interval"`  // Seconds between file verification checks
+	AccessLogPath     string `json:"access_log_path"`     // Path to access log file
+	AppLogPath        string `json:"app_log_path"`        // Path to application log file
+	LogLevel          string `json:"log_level"`           // Log level (debug, info, warn, error, panic)
+	MaxLogSize        int    `json:"max_log_size"`        // Maximum log size in bytes before rotation
+	LogVerifyInterval int    `json:"log_verify_interval"` // Seconds between file verification checks
 
 	// Status monitoring (optional)
 	StatusDir string `json:"status_dir"` // Directory for status files (last_start, running, last_stop)
@@ -141,6 +141,10 @@ func LoadConfig(path string, config *Config) error {
 	}
 	if config.IdleTimeout < 0 {
 		return fmt.Errorf("idle_timeout must not be negative, got %d", config.IdleTimeout)
+	}
+	if config.PasvPortRange[0] < 1 || config.PasvPortRange[1] > 65535 || config.PasvPortRange[0] > config.PasvPortRange[1] {
+		return fmt.Errorf("pasv_port_range must be an ascending range within 1-65535, got [%d, %d]",
+			config.PasvPortRange[0], config.PasvPortRange[1])
 	}
 
 	return nil

--- a/cmd/vkftpd/main.go
+++ b/cmd/vkftpd/main.go
@@ -113,16 +113,17 @@ Configuration file must be in JSON format with the following structure:
 
 		// Create and start FTP server
 		server, err := ftpserver.New(&ftpserver.Config{
-			ListenAddr:    config.ListenAddr,
-			Port:          config.Port,
-			RootDir:       config.FTPRootDir,
-			HomePattern:   config.HomePattern,
-			TLSCertFile:   config.TLSCertFile,
-			TLSKeyFile:    config.TLSKeyFile,
-			PasvPortRange: config.PasvPortRange,
-			PasvAddress:   config.PasvAddress,
-			PasvIPVerify:  config.PasvIPVerify,
-			IdleTimeout:   config.IdleTimeout,
+			ListenAddr:     config.ListenAddr,
+			Port:           config.Port,
+			RootDir:        config.FTPRootDir,
+			HomePattern:    config.HomePattern,
+			TLSCertFile:    config.TLSCertFile,
+			TLSKeyFile:     config.TLSKeyFile,
+			PasvPortRange:  config.PasvPortRange,
+			PasvAddress:    config.PasvAddress,
+			PasvIPVerify:   config.PasvIPVerify,
+			IdleTimeout:    config.IdleTimeout,
+			MaxConnections: config.MaxConnections,
 		}, authorizer, authenticator, version)
 		if err != nil {
 			return fmt.Errorf("failed to create FTP server: %w", err)

--- a/pkg/ftpserver/server.go
+++ b/pkg/ftpserver/server.go
@@ -4,9 +4,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -19,16 +21,17 @@ import (
 
 // Config holds the server configuration
 type Config struct {
-	ListenAddr    string // Address to listen on
-	Port          int    // Port to listen on
-	RootDir       string // Root directory that FTP users will be restricted to
-	HomePattern   string // Pattern for user home directories (e.g., "/home/%s")
-	TLSCertFile   string // Path to TLS certificate file
-	TLSKeyFile    string // Path to TLS private key file
-	PasvPortRange [2]int // Range of ports for passive mode transfers
-	PasvAddress   string // Public IP for passive mode connections
-	PasvIPVerify  bool   // Whether to verify data connection IPs
-	IdleTimeout   int    // Connection idle timeout in seconds (0 = library default)
+	ListenAddr     string // Address to listen on
+	Port           int    // Port to listen on
+	RootDir        string // Root directory that FTP users will be restricted to
+	HomePattern    string // Pattern for user home directories (e.g., "/home/%s")
+	TLSCertFile    string // Path to TLS certificate file
+	TLSKeyFile     string // Path to TLS private key file
+	PasvPortRange  [2]int // Range of ports for passive mode transfers
+	PasvAddress    string // Public IP for passive mode connections
+	PasvIPVerify   bool   // Whether to verify data connection IPs
+	IdleTimeout    int    // Connection idle timeout in seconds (0 = library default)
+	MaxConnections int    // Maximum concurrent connections (0 = unlimited)
 }
 
 // Server wraps the FTP server with our custom auth
@@ -103,7 +106,7 @@ var errNoTLS = errors.New("TLS is not configured")
 // Interface: ftpserverlib.MainDriver
 func (d *ftpDriver) GetSettings() (*ftpserverlib.Settings, error) {
 	settings := &ftpserverlib.Settings{
-		ListenAddr: fmt.Sprintf("%s:%d", d.server.config.ListenAddr, d.server.config.Port),
+		ListenAddr: net.JoinHostPort(d.server.config.ListenAddr, strconv.Itoa(d.server.config.Port)),
 		PassiveTransferPortRange: &ftpserverlib.PortRange{
 			Start: d.server.config.PasvPortRange[0],
 			End:   d.server.config.PasvPortRange[1],
@@ -129,9 +132,16 @@ func (d *ftpDriver) GetSettings() (*ftpserverlib.Settings, error) {
 // ClientConnected is called when a client connects
 // Interface: ftpserverlib.MainDriver
 func (d *ftpDriver) ClientConnected(cc ftpserverlib.ClientContext) (string, error) {
-	// Increment active connection counter
-	d.server.activeConnections.Add(1)
-	// Increment total connection counter
+	// Increment active connection counter. On refusal we leave it incremented:
+	// ftpserverlib still calls ClientDisconnected (via a deferred end()) even
+	// when ClientConnected returns an error, so the decrement there balances it.
+	active := d.server.activeConnections.Add(1)
+	if max := d.server.config.MaxConnections; max > 0 && active > int32(max) {
+		logging.Access.LogAccess("connect", "", cc.RemoteAddr().String(), "denied", "error", "connection limit reached")
+		return "Too many connections, please try again later", fmt.Errorf("connection limit reached")
+	}
+
+	// Only count accepted connections toward the lifetime total.
 	d.server.totalConnections.Add(1)
 
 	// Enable debug logging if log level is debug
@@ -230,25 +240,8 @@ func (c *ftpClient) resolvePath(name string) (string, error) {
 	return filepath.Clean(filepath.Join(currentPath, name)), nil
 }
 
-// GetFS returns the filesystem
-// Interface: ftpserverlib.ClientDriver
-func (c *ftpClient) GetFS() afero.Fs {
-	return c
-}
-
-// ChangeCwd implements directory change
-// Interface: ftpserverlib.ClientDriver
-func (c *ftpClient) ChangeCwd(path string) error {
-	if !c.server.authorizer.CanRead(c.user, path) {
-		logging.Access.LogAccess("chdir", c.user, path, "denied")
-		return os.ErrPermission
-	}
-	logging.Access.LogAccess("chdir", c.user, path, "success")
-	return nil
-}
-
-// ReadDir is required for directory listing
-// Interface: ftpserverlib.ClientDriver
+// ReadDir returns a directory listing.
+// Interface: ftpserverlib.ClientDriverExtensionFileList
 func (c *ftpClient) ReadDir(name string) ([]os.FileInfo, error) {
 	path, err := c.resolvePath(name)
 	if err != nil {
@@ -285,50 +278,6 @@ func (c *ftpClient) ReadDir(name string) ([]os.FileInfo, error) {
 
 	logging.Access.LogAccess("readdir", c.user, path, "success", "count", len(entries))
 	return entries, nil
-}
-
-// DeleteFile implements file deletion
-// Interface: ftpserverlib.ClientDriver
-func (c *ftpClient) DeleteFile(name string) error {
-	path, err := c.resolvePath(name)
-	if err != nil {
-		return err
-	}
-
-	if !c.server.authorizer.CanWrite(c.user, path) {
-		logging.Access.LogAccess("remove", c.user, name, "denied", "error", err)
-		return os.ErrPermission
-	}
-
-	if err := c.fs.Remove(path); err != nil {
-		logging.Access.LogAccess("remove", c.user, name, "error", "error", err)
-		return err
-	}
-
-	logging.Access.LogAccess("remove", c.user, name, "success")
-	return nil
-}
-
-// MakeDirectory implements directory creation
-// Interface: ftpserverlib.ClientDriver
-func (c *ftpClient) MakeDirectory(name string) error {
-	path, err := c.resolvePath(name)
-	if err != nil {
-		return err
-	}
-
-	if !c.server.authorizer.CanWrite(c.user, path) {
-		logging.Access.LogAccess("mkdir", c.user, path, "denied", "error", os.ErrPermission)
-		return os.ErrPermission
-	}
-
-	if err := c.fs.Mkdir(path, 0755); err != nil {
-		logging.Access.LogAccess("mkdir", c.user, path, "error", "error", err)
-		return err
-	}
-
-	logging.Access.LogAccess("mkdir", c.user, path, "success")
-	return nil
 }
 
 // Open opens a file for reading
@@ -368,20 +317,20 @@ func (c *ftpClient) OpenFile(name string, flag int, perm os.FileMode) (afero.Fil
 	}
 
 	// Check write permission if file is being created or modified
-	if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+	writing := flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0
+	if writing {
 		if !c.server.authorizer.CanWrite(c.user, path) {
 			logging.Access.LogAccess("open", c.user, path, "denied", "error", os.ErrPermission)
 			return nil, os.ErrPermission
 		}
-		logging.Access.LogAccess("open", c.user, path, "success", "mode", "write")
 	} else if !c.server.authorizer.CanRead(c.user, path) {
 		logging.Access.LogAccess("open", c.user, path, "denied", "error", os.ErrPermission)
 		return nil, os.ErrPermission
 	}
 
-	file, err := c.fs.OpenFile(path, flag, perm)
+	file, err := c.fs.OpenFile(path, flag, clampPerm(perm))
 	if err != nil {
-		if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		if writing {
 			logging.Access.LogAccess("open", c.user, path, "error", "mode", "write")
 		} else {
 			logging.Access.LogAccess("open", c.user, path, "error", "mode", "read")
@@ -389,15 +338,21 @@ func (c *ftpClient) OpenFile(name string, flag int, perm os.FileMode) (afero.Fil
 		return nil, err
 	}
 
-	// Only log size for read operations
-	if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) == 0 {
-		if fi, err := file.Stat(); err == nil {
-			logging.Access.LogAccess("open", c.user, path, "success", "size", fi.Size())
-		} else {
-			logging.Access.LogAccess("open", c.user, path, "success", "size", 0)
-		}
+	if writing {
+		logging.Access.LogAccess("open", c.user, path, "success", "mode", "write")
+	} else if fi, err := file.Stat(); err == nil {
+		logging.Access.LogAccess("open", c.user, path, "success", "size", fi.Size())
+	} else {
+		logging.Access.LogAccess("open", c.user, path, "success", "size", 0)
 	}
 	return file, nil
+}
+
+// clampPerm restricts file-creation permissions. ftpserverlib passes
+// os.ModePerm (0777) for uploads; without clamping, uploaded files land at
+// 0777&^umask, which is world-writable under a permissive umask.
+func clampPerm(perm os.FileMode) os.FileMode {
+	return perm & 0644
 }
 
 // Create creates a new file
@@ -413,7 +368,8 @@ func (c *ftpClient) Create(name string) (afero.File, error) {
 		return nil, os.ErrPermission
 	}
 
-	file, err := c.fs.Create(path)
+	// afero's Create uses 0666; open explicitly so uploads get clamped perms.
+	file, err := c.fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, clampPerm(os.ModePerm))
 	if err != nil {
 		logging.Access.LogAccess("create", c.user, path, "error", "error", err)
 		return nil, err
@@ -457,9 +413,14 @@ func (c *ftpClient) MkdirAll(path string, perm os.FileMode) error {
 		logging.Access.LogAccess("mkdir", c.user, resolvedPath, "denied", "error", os.ErrPermission)
 		return os.ErrPermission
 	}
-	err = c.fs.MkdirAll(resolvedPath, perm)
+
+	if err := c.fs.MkdirAll(resolvedPath, perm); err != nil {
+		logging.Access.LogAccess("mkdir", c.user, resolvedPath, "error", "error", err)
+		return err
+	}
+
 	logging.Access.LogAccess("mkdir", c.user, resolvedPath, "success", "mode", "write")
-	return err
+	return nil
 }
 
 // Remove removes a file
@@ -520,16 +481,16 @@ func (c *ftpClient) Rename(oldname, newname string) error {
 
 	if !c.server.authorizer.CanWrite(c.user, oldPath) ||
 		!c.server.authorizer.CanWrite(c.user, newPath) {
-		logging.Access.LogAccess("rename", c.user, oldPath, "denied", "error", os.ErrPermission)
+		logging.Access.LogAccess("rename", c.user, oldPath, "denied", "error", os.ErrPermission, "to", newPath)
 		return os.ErrPermission
 	}
 
 	if err := c.fs.Rename(oldPath, newPath); err != nil {
-		logging.Access.LogAccess("rename", c.user, oldPath, "error", "error", err)
+		logging.Access.LogAccess("rename", c.user, oldPath, "error", "error", err, "to", newPath)
 		return err
 	}
 
-	logging.Access.LogAccess("rename", c.user, oldPath, "success", "mode", "write")
+	logging.Access.LogAccess("rename", c.user, oldPath, "success", "mode", "write", "to", newPath)
 	return nil
 }
 
@@ -542,6 +503,7 @@ func (c *ftpClient) Stat(name string) (os.FileInfo, error) {
 	}
 
 	if !c.server.authorizer.CanRead(c.user, path) {
+		logging.Access.LogAccess("stat", c.user, path, "denied", "error", os.ErrPermission)
 		return nil, os.ErrPermission
 	}
 	return c.fs.Stat(path)
@@ -562,9 +524,15 @@ func (c *ftpClient) Chmod(name string, mode os.FileMode) error {
 	}
 
 	if !c.server.authorizer.CanWrite(c.user, path) {
+		logging.Access.LogAccess("chmod", c.user, path, "denied", "error", os.ErrPermission)
 		return os.ErrPermission
 	}
-	return c.fs.Chmod(path, mode)
+	if err := c.fs.Chmod(path, mode); err != nil {
+		logging.Access.LogAccess("chmod", c.user, path, "error", "error", err)
+		return err
+	}
+	logging.Access.LogAccess("chmod", c.user, path, "success", "mode", "write")
+	return nil
 }
 
 // Chown changes file owner
@@ -576,9 +544,15 @@ func (c *ftpClient) Chown(name string, uid, gid int) error {
 	}
 
 	if !c.server.authorizer.CanWrite(c.user, path) {
+		logging.Access.LogAccess("chown", c.user, path, "denied", "error", os.ErrPermission)
 		return os.ErrPermission
 	}
-	return c.fs.Chown(path, uid, gid)
+	if err := c.fs.Chown(path, uid, gid); err != nil {
+		logging.Access.LogAccess("chown", c.user, path, "error", "error", err)
+		return err
+	}
+	logging.Access.LogAccess("chown", c.user, path, "success", "mode", "write")
+	return nil
 }
 
 // Chtimes changes file times
@@ -590,7 +564,13 @@ func (c *ftpClient) Chtimes(name string, atime time.Time, mtime time.Time) error
 	}
 
 	if !c.server.authorizer.CanWrite(c.user, path) {
+		logging.Access.LogAccess("chtimes", c.user, path, "denied", "error", os.ErrPermission)
 		return os.ErrPermission
 	}
-	return c.fs.Chtimes(path, atime, mtime)
+	if err := c.fs.Chtimes(path, atime, mtime); err != nil {
+		logging.Access.LogAccess("chtimes", c.user, path, "error", "error", err)
+		return err
+	}
+	logging.Access.LogAccess("chtimes", c.user, path, "success", "mode", "write")
+	return nil
 }

--- a/pkg/ftpserver/server_test.go
+++ b/pkg/ftpserver/server_test.go
@@ -1,0 +1,25 @@
+package ftpserver
+
+import (
+	"os"
+	"testing"
+)
+
+func TestClampPerm(t *testing.T) {
+	tests := []struct {
+		in   os.FileMode
+		want os.FileMode
+	}{
+		{os.ModePerm, 0644}, // ftpserverlib passes 0777 for uploads
+		{0777, 0644},        // no world/group write
+		{0666, 0644},        // typical create mode
+		{0600, 0600},        // already restrictive, unchanged
+		{0640, 0640},        // group-read preserved
+		{0000, 0000},        // no bits
+	}
+	for _, tc := range tests {
+		if got := clampPerm(tc.in); got != tc.want {
+			t.Errorf("clampPerm(%o) = %o, want %o", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/logging/types.go
+++ b/pkg/logging/types.go
@@ -101,6 +101,11 @@ func Shutdown() {
 // formatValue formats a value for logfmt, quoting if necessary
 func formatValue(v interface{}) string {
 	s := fmt.Sprintf("%v", v)
+	// Neutralize control characters so a crafted username or path cannot forge
+	// or split access-log lines (consistent with the app logger's handling).
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\t", " ")
 	// Quote if contains space, equals, or quotes
 	if strings.ContainsAny(s, " =\"") {
 		// Escape existing quotes

--- a/pkg/logging/types_test.go
+++ b/pkg/logging/types_test.go
@@ -1,0 +1,39 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{"plain", "hello", "hello"},
+		{"space is quoted", "a b", `"a b"`},
+		{"equals is quoted", "a=b", `"a=b"`},
+		{"quote is escaped", `a"b`, `"a\"b"`},
+		{"newline neutralized to space", "a\nb", `"a b"`},
+		{"carriage return neutralized to space", "a\rb", `"a b"`},
+		{"tab neutralized to space", "a\tb", `"a b"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatValue(tc.in); got != tc.want {
+				t.Errorf("formatValue(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatValueNoLineForging ensures a crafted value cannot inject a second
+// log line via CR/LF.
+func TestFormatValueNoLineForging(t *testing.T) {
+	forged := "victim status=success\nop=fake user=attacker"
+	got := formatValue(forged)
+	if strings.ContainsAny(got, "\r\n") {
+		t.Errorf("formatValue left a line break in output: %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #17

A correctness pass on the FTP driver, grounded in ftpserverlib v0.25.0 sources. No authorization bypass was found — every FTP verb was traced to an authorized method — but a number of correctness, security, and audit issues were fixed:

- **Dead code removed:** `GetFS`, `ChangeCwd`, `DeleteFile`, `MakeDirectory`. In v0.25.0 `ClientDriver` is exactly `afero.Fs`, so these are never called (DELE routes to `Remove`, MKD to `Mkdir`, verified live). Their interface comments were misleading, and the intended `op=chdir` audit line was never actually emitted.
- **Upload permissions clamped to 0644** in `OpenFile` and `Create`. ftpserverlib passes `os.ModePerm` (0777) for STOR and the driver forwarded it, leaving uploads world-writable under a permissive umask.
- **`max_connections` is now enforced** in `ClientConnected`. Returning an error refuses the connection; ftpserverlib still calls `ClientDisconnected` via a deferred `end()`, so the active counter stays balanced.
- **Audit logging added** to `Stat`/`Chmod`/`Chown`/`Chtimes` denials and successes, and rename logs now include the destination path. These are the only authorization paths for CWD, SIZE, MDTM, RNFR, SITE CHMOD/CHOWN, and MFMT.
- **Log bugs fixed:** `OpenFile` logged a write open as success before attempting it (and again as error on failure); `MkdirAll` logged success unconditionally.
- **Log-injection hardening:** access-log values now neutralize CR/LF/tab, so a crafted username or path can't forge or split log lines (the app logger already did this).
- **Nits:** listen address built with `net.JoinHostPort` (IPv6-safe); `pasv_port_range` and negative `idle_timeout` validated at config load.

Adds unit tests for `clampPerm` and the log value sanitizer. Verified end to end against a running daemon: uploads land at 0644, and MKD/DELE/download/permission-denials all still work through the afero methods after the dead-code removal. Full suite passes under `go test -race ./...`.

Notes for follow-up (not in this PR):
- `max_connections` is now enforced for FTP as well as SFTP (PR #14); the SFTP PR's README note calling it SFTP-only will be reconciled when both land.
- TLS cert is still reloaded from disk on every AUTH/FEAT (cheap amplification); worth caching with mtime refresh later.
- The shared authorize→log→delegate policy is still duplicated with the SFTP handlers; a `pkg/vfs` extraction to unify it is planned as a follow-up, which will also add full FTP driver unit tests.

https://claude.ai/code/session_01LVejDJLbKQar4kPkaAsPrF