### PR TITLE
fix(users): reject path-traversal usernames before file access

### DIFF
--- a/pkg/users/file_source.go
+++ b/pkg/users/file_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/mmcdole/viking-ftpd/pkg/logging"
@@ -16,6 +17,11 @@ const (
 	// LevelField is the field name for the user's level
 	LevelField = "level"
 )
+
+// validUsername restricts usernames to characters that cannot escape the
+// character directory when joined into a filesystem path. This blocks path
+// traversal (e.g. "../../etc/passwd") before any file access.
+var validUsername = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // FileSource implements Source using the filesystem
 type FileSource struct {
@@ -32,9 +38,6 @@ func NewFileSource(rootDir string) *FileSource {
 
 // getCharacterPath returns the full path to a user file
 func (s *FileSource) getCharacterPath(username string) string {
-	if username == "" {
-		return ""
-	}
 	// Get first letter of username for subdirectory
 	firstLetter := strings.ToLower(username[0:1])
 	path := filepath.Join(s.rootDir, firstLetter, username+".o")
@@ -43,11 +46,16 @@ func (s *FileSource) getCharacterPath(username string) string {
 
 // LoadUser implements Source
 func (s *FileSource) LoadUser(username string) (*User, error) {
-	path := s.getCharacterPath(username)
-	if path == "" {
-		logging.App.Debug("Invalid username provided", "username", username)
-		return nil, fmt.Errorf("invalid username")
+	// Reject usernames that could traverse outside the character directory.
+	// Return ErrUserNotFound (not a distinct error) so the authenticator still
+	// runs its constant-time dummy verification and cannot leak, via error or
+	// timing, whether a name was invalid versus simply unknown.
+	if !validUsername.MatchString(username) {
+		logging.App.Debug("Rejected invalid username", "username", username)
+		return nil, ErrUserNotFound
 	}
+
+	path := s.getCharacterPath(username)
 
 	// Check if file exists
 	data, err := os.ReadFile(path)

--- a/pkg/users/username_validation_test.go
+++ b/pkg/users/username_validation_test.go
@@ -1,0 +1,73 @@
+package users
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadUserRejectsTraversalNames ensures usernames that could escape the
+// character directory are rejected with ErrUserNotFound before any file access.
+// A planted file outside the sharded layout must never be reachable.
+func TestLoadUserRejectsTraversalNames(t *testing.T) {
+	root := t.TempDir()
+
+	// Plant a valid-looking character file one level above the character root,
+	// which a traversal username would otherwise reach.
+	outside := filepath.Join(root, "secret.o")
+	if err := os.WriteFile(outside, []byte(`password "x"`+"\nlevel 50\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	charDir := filepath.Join(root, "chars")
+	if err := os.MkdirAll(charDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	source := NewFileSource(charDir)
+
+	bad := []string{
+		"../secret",
+		"../../secret",
+		"a/../../secret",
+		"foo/bar",
+		"foo.bar",
+		`foo\bar`,
+		"",
+		".",
+		"..",
+		"foo bar",
+	}
+	for _, name := range bad {
+		t.Run(name, func(t *testing.T) {
+			_, err := source.LoadUser(name)
+			if err != ErrUserNotFound {
+				t.Errorf("LoadUser(%q) = %v, want ErrUserNotFound", name, err)
+			}
+		})
+	}
+}
+
+// TestLoadUserAcceptsValidNames confirms ordinary names still load.
+func TestLoadUserAcceptsValidNames(t *testing.T) {
+	root := t.TempDir()
+	source := NewFileSource(root)
+
+	for _, name := range []string{"alice", "Bob", "wiz_99", "a-b", "x"} {
+		dir := filepath.Join(root, strings.ToLower(name[0:1]))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name+".o"), []byte(`password "h"`+"\nlevel 1\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		u, err := source.LoadUser(name)
+		if err != nil {
+			t.Errorf("LoadUser(%q) unexpected error: %v", name, err)
+			continue
+		}
+		if u.Username != name {
+			t.Errorf("LoadUser(%q).Username = %q", name, u.Username)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #19

`FileSource` joined the raw login username into the character-file path (`filepath.Join(rootDir, firstLetter, username+".o")`), so a username like `../../x` resolved outside `character_dir_path` and could authenticate against any readable file that parses as an LPC character object with a password field. FTP and SFTP shared the exposure.

The fix validates the username against `^[a-zA-Z0-9_-]+$` at the top of `LoadUser` and returns `ErrUserNotFound` on rejection. Returning the ordinary not-found error (rather than a distinct one) is deliberate: the authenticator still runs its constant-time dummy-hash verification, so an invalid name stays indistinguishable from an unknown user by both error message and timing.

Tests cover traversal names (`../secret`, `foo/bar`, `foo.bar`, `..`, empty, etc. — verified failing without the fix, where `../secret` reached a planted file) and ordinary names (`alice`, `Bob`, `wiz_99`, `a-b`). Passes under `go test -race ./...`.

https://claude.ai/code/session_01LVejDJLbKQar4kPkaAsPrF