### PR TITLE
fix(lpc,authorization): harden access tree parsing against malformed input

### DIFF
--- a/pkg/authorization/access_tree_builder.go
+++ b/pkg/authorization/access_tree_builder.go
@@ -114,16 +114,25 @@ func buildAccessNode(data map[string]interface{}) (*AccessNode, []string, error)
 	return node, groups, nil
 }
 
-// parsePermission converts a raw permission value into a Permission
+// parsePermission converts a raw permission value into a Permission and
+// rejects values outside the defined range, so a malformed access tree fails
+// to build rather than silently granting (e.g. a stray 7 reading as CanGrant)
+// or blocking resolution with a nonsense level.
 func parsePermission(value interface{}) (Permission, error) {
+	var perm Permission
 	switch v := value.(type) {
 	case float64:
-		return Permission(int(v)), nil
+		perm = Permission(int(v))
 	case int:
-		return Permission(v), nil
+		perm = Permission(v)
 	case Permission:
-		return v, nil
+		perm = v
 	default:
 		return Revoked, fmt.Errorf("invalid permission format: expected number or Permission, got %T", value)
 	}
+
+	if !perm.isValid() {
+		return Revoked, fmt.Errorf("permission value out of range: %d", int(perm))
+	}
+	return perm, nil
 }

--- a/pkg/authorization/access_tree_builder_test.go
+++ b/pkg/authorization/access_tree_builder_test.go
@@ -1,0 +1,32 @@
+package authorization
+
+import "testing"
+
+func TestBuildAccessTreesRejectsInvalidPermission(t *testing.T) {
+	// Values come off the LPC parser as plain ints; anything outside
+	// {-1, 1..5} is malformed and must fail the build rather than resolve to a
+	// nonsense permission level.
+	for _, bad := range []int{0, 7, -5, 100, -2} {
+		raw := map[string]interface{}{
+			"access_map": map[string]interface{}{
+				"*": map[string]interface{}{".": bad},
+			},
+		}
+		if _, err := BuildAccessTrees(raw); err == nil {
+			t.Errorf("BuildAccessTrees accepted out-of-range permission %d, want error", bad)
+		}
+	}
+}
+
+func TestBuildAccessTreesAcceptsValidPermissions(t *testing.T) {
+	for _, ok := range []int{-1, 1, 2, 3, 4, 5} {
+		raw := map[string]interface{}{
+			"access_map": map[string]interface{}{
+				"*": map[string]interface{}{".": ok},
+			},
+		}
+		if _, err := BuildAccessTrees(raw); err != nil {
+			t.Errorf("BuildAccessTrees rejected valid permission %d: %v", ok, err)
+		}
+	}
+}

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -17,6 +17,13 @@ const (
 	GrantGrant Permission = 5
 )
 
+// isValid reports whether p is one of the defined permission levels. Note that
+// 0 is not a valid level: LPC mappings cannot store a 0 value (assigning 0
+// deletes the key), so an access entry is always Revoked (-1) or Read..GrantGrant.
+func (p Permission) isValid() bool {
+	return p == Revoked || (p >= Read && p <= GrantGrant)
+}
+
 // CanRead returns true if the permission allows reading
 func (p Permission) CanRead() bool {
 	return p >= Read

--- a/pkg/lpc/oparser.go
+++ b/pkg/lpc/oparser.go
@@ -67,12 +67,23 @@ func NewLineParser(line string) *LineParser {
 // The input should consist of key-value pairs, one per line.
 // Empty lines and lines starting with # are ignored.
 // Returns error if input is empty or invalid.
-func (p *ObjectParser) ParseObject(input string) (*ParseResult, error) {
+func (p *ObjectParser) ParseObject(input string) (result *ParseResult, err error) {
+	// Never let a malformed object crash the caller. This parser runs on
+	// machine-generated files (the access tree, character files) that can be
+	// read mid-write; a panic here would otherwise take down the daemon, since
+	// the SFTP request server does not recover per-operation.
+	defer func() {
+		if r := recover(); r != nil {
+			result = nil
+			err = fmt.Errorf("panic while parsing object: %v", r)
+		}
+	}()
+
 	if len(input) == 0 {
 		return nil, fmt.Errorf("input string is empty")
 	}
 
-	result := &ParseResult{
+	result = &ParseResult{
 		Object: make(map[string]interface{}),
 		Errors: make([]*ParseError, 0),
 	}
@@ -527,6 +538,11 @@ func (p *LineParser) skipSpaces() {
 
 // match checks if the next runes match the given string and advances the position if they do
 func (p *LineParser) match(s string) bool {
+	// Bounds check: a truncated value (e.g. a line ending in "n" while trying
+	// to match "nil") must not slice past the end of the input and panic.
+	if p.pos+len(s) > len(p.s) {
+		return false
+	}
 	if p.s[p.pos:p.pos+len(s)] == s {
 		p.pos += len(s)
 		return true

--- a/pkg/lpc/robustness_test.go
+++ b/pkg/lpc/robustness_test.go
@@ -1,0 +1,44 @@
+package lpc
+
+import "testing"
+
+// TestParseObjectNoPanicOnTruncatedInput covers malformed/truncated objects
+// that must produce a parse error rather than crashing. The "nil" cases in
+// particular previously panicked in match() by slicing past the end of the
+// line while trying to match the literal "nil".
+func TestParseObjectNoPanicOnTruncatedInput(t *testing.T) {
+	inputs := []string{
+		"x n",                    // value truncated to "n"
+		"x ni",                   // value truncated to "ni"
+		"n",                      // no key/value, starts with n
+		"m ([1|\"a\":n",          // truncated nil inside a mapping
+		"a ({1|n",                // truncated nil inside an array
+		"m ([2|\"a\":1,\"b\":ni", // truncated nil as a later map value
+		"x (",                    // truncated container
+		"x ({",                   // truncated array open
+		"x ([",                   // truncated map open
+		"x \"unterminated",       // unterminated string
+		"m ([1|\"k\":({2|1,2",    // truncated nested array
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			// The assertion is simply that neither parser mode panics; a panic
+			// here would fail the subtest.
+			_, _ = NewObjectParser(false).ParseObject(in)
+			_, _ = NewObjectParser(true).ParseObject(in)
+		})
+	}
+}
+
+// TestParseObjectValidNilStillWorks guards against the bounds fix breaking the
+// normal nil path.
+func TestParseObjectValidNilStillWorks(t *testing.T) {
+	res, err := NewObjectParser(true).ParseObject("value nil")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v, ok := res.Object["value"]
+	if !ok || v != nil {
+		t.Fatalf("expected value=nil, got %#v (present=%v)", v, ok)
+	}
+}


### PR DESCRIPTION
Addresses the robustness findings in #22 (items 1-3). No change to authorization resolution for well-formed trees; this is purely about failing safely on bad input.

The access tree (`access.o`) and character files are machine-generated and can be read mid-write, so the parser has to tolerate truncated/garbage input without crashing or silently accepting nonsense.

- **match() bounds check** (`pkg/lpc/oparser.go`): a value truncated to `n` or `ni` made `match("nil")` slice past the end of the line and panic. `access.o` is one long line, so a mid-write truncation lands mid-line with decent odds. `pkg/sftp` doesn't recover per-operation, so that panic takes down the whole daemon. This is the root-cause fix.
- **recover at the parse boundary** (`ParseObject`): converts any remaining malformed-input panic into an error instead of a crash. Defense in depth, since the parser also runs on character files during SSH auth.
- **parsePermission range check**: rejects permission values outside `{-1, 1..5}`, so a malformed tree fails to build rather than resolving to a nonsense level (a stray 7 would otherwise report `CanGrant`).

Tests: a table of truncated inputs that must not panic (verified to panic — `slice bounds out of range` — without the fix), a check that valid `nil` still parses, and build-rejects/accepts cases for permission values. Full suite passes under `go test -race ./...`.

The deeper correctness divergences from `resources/access.c` (items 4-7 in #22 — the implicit open/own-dir rule, dot-vs-star inheritance, explicit-revoke masking, ancestor-default threading) are a change to authorization behavior and belong in their own PR. They're latent on the current production data but worth porting `eval_map`'s exact semantics for; I'd rather do that separately with a test suite validated against `access.c` than fold it in here.

https://claude.ai/code/session_01LVejDJLbKQar4kPkaAsPrF