### PR TITLE
fix(authorization): match the MUD's access resolver (eval_map)

### DIFF
--- a/pkg/authorization/access_tree_builder.go
+++ b/pkg/authorization/access_tree_builder.go
@@ -2,122 +2,52 @@ package authorization
 
 import "fmt"
 
-// BuildAccessTrees constructs a map of access trees from raw data
-func BuildAccessTrees(rawData map[string]interface{}) (map[string]*AccessTree, error) {
-	result := make(map[string]*AccessTree)
-
-	// Look for access_map key
+// loadAccessMap extracts the "access_map" from raw parsed data and validates
+// it. Resolution works directly on the raw map (mirroring the MUD), so this
+// only checks structure and permission ranges up front so a malformed file
+// fails to load rather than resolving to nonsense at request time.
+func loadAccessMap(rawData map[string]interface{}) (map[string]interface{}, error) {
 	accessMap, ok := rawData["access_map"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("access_map not found or invalid format")
 	}
-
-	for username, rawUserTree := range accessMap {
-		userMap, ok := rawUserTree.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("invalid user tree format for %s: expected map[string]interface{}, got %T", username, rawUserTree)
-		}
-		tree, err := buildAccessTree(userMap)
-		if err != nil {
-			return nil, fmt.Errorf("building tree for user %s: %w", username, err)
-		}
-		result[username] = tree
-	}
-	return result, nil
-}
-
-// buildAccessTree constructs an access tree from raw data
-func buildAccessTree(data map[string]interface{}) (*AccessTree, error) {
-	root, groups, err := buildAccessNode(data)
-	if err != nil {
+	if err := validateNode(accessMap); err != nil {
 		return nil, err
 	}
-
-	return &AccessTree{
-		Root:   root,
-		Groups: groups,
-	}, nil
+	return accessMap, nil
 }
 
-// buildAccessNode recursively constructs an access node from raw data
-func buildAccessNode(data map[string]interface{}) (*AccessNode, []string, error) {
-	node := &AccessNode{
-		DotAccess:  Revoked,
-		StarAccess: Revoked,
-		Children:   make(map[string]*AccessNode),
-	}
-
-	var groups []string
-
-	for key, value := range data {
-		switch key {
-		case ".":
-			perm, err := parsePermission(value)
-			if err != nil {
-				return nil, nil, fmt.Errorf("parsing dot access: %w", err)
+// validateNode recursively checks that every leaf is a valid permission, every
+// subtree is a map, and every "?" entry is a list of group-name strings.
+func validateNode(node map[string]interface{}) error {
+	for key, value := range node {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			if err := validateNode(v); err != nil {
+				return err
 			}
-			node.DotAccess = perm
-		case "*":
-			// Star access can be either a direct permission or a directory node
-			if childMap, ok := value.(map[string]interface{}); ok {
-				child, childGroups, err := buildAccessNode(childMap)
-				if err != nil {
-					return nil, nil, fmt.Errorf("building star directory: %w", err)
-				}
-				node.Children["*"] = child
-				groups = append(groups, childGroups...)
-			} else {
-				perm, err := parsePermission(value)
-				if err != nil {
-					return nil, nil, fmt.Errorf("parsing star access: %w", err)
-				}
-				node.StarAccess = perm
+		case []interface{}:
+			if key != "?" {
+				return fmt.Errorf("unexpected list value for key %q", key)
 			}
-		case "?":
-			groupList, ok := value.([]interface{})
-			if !ok {
-				return nil, nil, fmt.Errorf("invalid group list format: expected []interface{}, got %T", value)
-			}
-			for _, group := range groupList {
-				groupStr, ok := group.(string)
-				if !ok {
-					return nil, nil, fmt.Errorf("invalid group name format: expected string, got %T", group)
+			for _, g := range v {
+				if _, ok := g.(string); !ok {
+					return fmt.Errorf("invalid group name format: expected string, got %T", g)
 				}
-				groups = append(groups, groupStr)
 			}
 		default:
-			switch v := value.(type) {
-			case map[string]interface{}:
-				child, childGroups, err := buildAccessNode(v)
-				if err != nil {
-					return nil, nil, fmt.Errorf("building child node %s: %w", key, err)
-				}
-				if len(childGroups) > 0 {
-					groups = append(groups, childGroups...)
-				}
-				node.Children[key] = child
-			default:
-				// Handle direct permission value
-				perm, err := parsePermission(value)
-				if err != nil {
-					return nil, nil, fmt.Errorf("parsing permission for %s: %w", key, err)
-				}
-				child := &AccessNode{
-					DotAccess:  perm,
-					StarAccess: perm,
-					Children:   make(map[string]*AccessNode),
-				}
-				node.Children[key] = child
+			if _, err := parsePermission(value); err != nil {
+				return fmt.Errorf("key %q: %w", key, err)
 			}
 		}
 	}
-	return node, groups, nil
+	return nil
 }
 
-// parsePermission converts a raw permission value into a Permission and
-// rejects values outside the defined range, so a malformed access tree fails
-// to build rather than silently granting (e.g. a stray 7 reading as CanGrant)
-// or blocking resolution with a nonsense level.
+// parsePermission converts a raw permission value into a Permission and rejects
+// values outside the defined range, so a malformed access tree fails to build
+// rather than silently granting (e.g. a stray 7 reading as CanGrant) or
+// blocking resolution with a nonsense level.
 func parsePermission(value interface{}) (Permission, error) {
 	var perm Permission
 	switch v := value.(type) {

--- a/pkg/authorization/access_tree_builder_test.go
+++ b/pkg/authorization/access_tree_builder_test.go
@@ -2,9 +2,9 @@ package authorization
 
 import "testing"
 
-func TestBuildAccessTreesRejectsInvalidPermission(t *testing.T) {
+func TestLoadAccessMapRejectsInvalidPermission(t *testing.T) {
 	// Values come off the LPC parser as plain ints; anything outside
-	// {-1, 1..5} is malformed and must fail the build rather than resolve to a
+	// {-1, 1..5} is malformed and must fail to load rather than resolve to a
 	// nonsense permission level.
 	for _, bad := range []int{0, 7, -5, 100, -2} {
 		raw := map[string]interface{}{
@@ -12,21 +12,27 @@ func TestBuildAccessTreesRejectsInvalidPermission(t *testing.T) {
 				"*": map[string]interface{}{".": bad},
 			},
 		}
-		if _, err := BuildAccessTrees(raw); err == nil {
-			t.Errorf("BuildAccessTrees accepted out-of-range permission %d, want error", bad)
+		if _, err := loadAccessMap(raw); err == nil {
+			t.Errorf("loadAccessMap accepted out-of-range permission %d, want error", bad)
 		}
 	}
 }
 
-func TestBuildAccessTreesAcceptsValidPermissions(t *testing.T) {
+func TestLoadAccessMapAcceptsValidPermissions(t *testing.T) {
 	for _, ok := range []int{-1, 1, 2, 3, 4, 5} {
 		raw := map[string]interface{}{
 			"access_map": map[string]interface{}{
 				"*": map[string]interface{}{".": ok},
 			},
 		}
-		if _, err := BuildAccessTrees(raw); err != nil {
-			t.Errorf("BuildAccessTrees rejected valid permission %d: %v", ok, err)
+		if _, err := loadAccessMap(raw); err != nil {
+			t.Errorf("loadAccessMap rejected valid permission %d: %v", ok, err)
 		}
+	}
+}
+
+func TestLoadAccessMapMissingAccessMap(t *testing.T) {
+	if _, err := loadAccessMap(map[string]interface{}{}); err == nil {
+		t.Error("loadAccessMap accepted data without an access_map, want error")
 	}
 }

--- a/pkg/authorization/authorizer.go
+++ b/pkg/authorization/authorizer.go
@@ -11,14 +11,16 @@ import (
 	"github.com/mmcdole/viking-ftpd/pkg/users"
 )
 
-// Authorizer handles access control and permissions with caching
+// Authorizer resolves per-path permissions against the MUD's access map,
+// mirroring the MUD's own resolver (resources/access.c: _get_access / eval_map).
+// The access map is cached and refreshed on a TTL.
 type Authorizer struct {
 	source        AccessSource
 	characterData users.Source
 	cacheDuration time.Duration
 
 	mu          sync.RWMutex
-	trees       map[string]*AccessTree
+	accessMap   map[string]interface{} // raw "access_map": name -> raw tree
 	lastRefresh time.Time
 }
 
@@ -28,119 +30,12 @@ func NewAuthorizer(source AccessSource, characterData users.Source, cacheDuratio
 		source:        source,
 		characterData: characterData,
 		cacheDuration: cacheDuration,
-		trees:         make(map[string]*AccessTree),
 	}
 }
 
 // HasPermission checks if a user has the required permission for a path
 func (a *Authorizer) HasPermission(username string, filepath string, requiredPerm Permission) bool {
-	effectivePerm := a.ResolvePermission(username, filepath)
-	return effectivePerm >= requiredPerm
-}
-
-// ResolvePermission returns the effective permission for a user on a path
-func (a *Authorizer) ResolvePermission(username string, filepath string) Permission {
-	if err := a.ensureFreshCache(); err != nil {
-		logging.App.Debug("Cache refresh failed", "user", username, "path", filepath, "error", err)
-		return Revoked
-	}
-
-	// Snapshot the tree map under the read lock. refreshCache replaces the
-	// map wholesale rather than mutating it, so the captured reference is a
-	// stable, immutable view even if a concurrent refresh swaps in a new map.
-	a.mu.RLock()
-	trees := a.trees
-	a.mu.RUnlock()
-
-	// Clean the path and split into parts
-	parts := strings.Split(path.Clean(filepath), "/")
-	if len(parts) > 0 && parts[0] == "" {
-		parts = parts[1:]
-	}
-	// Handle root path specifically
-	if len(parts) == 1 && parts[0] == "" {
-		parts = []string{} // Empty array for root path
-	}
-
-	// Check implicit permissions first
-	if implicitPerm, ok := a.resolveImplicitPermission(username, parts); ok {
-		logging.App.Debug("Resolved implicit permission", "user", username, "path", filepath, "permission", implicitPerm)
-		return implicitPerm
-	}
-
-	// Check user's direct permissions
-	if tree, ok := trees[username]; ok {
-		perm := a.resolveNodePermission(tree.Root, parts)
-		if perm != Revoked {
-			logging.App.Debug("Resolved direct permission", "user", username, "path", filepath, "permission", perm)
-			return perm
-		}
-	}
-
-	// Check all group permissions (both explicit and implicit)
-	for _, group := range a.ResolveGroups(username) {
-		if tree, ok := trees[group]; ok {
-			perm := a.resolveNodePermission(tree.Root, parts)
-			if perm != Revoked {
-				logging.App.Debug("Resolved group permission", "user", username, "group", group, "path", filepath, "permission", perm)
-				return perm
-			}
-		}
-	}
-
-	// Finally check default permissions
-	if tree, ok := trees["*"]; ok {
-		perm := a.resolveNodePermission(tree.Root, parts)
-		logging.App.Debug("Using default permission", "user", username, "path", filepath, "permission", perm)
-		return perm
-	}
-
-	logging.App.Debug("No permission found, defaulting to revoked", "user", username, "path", filepath)
-	return Revoked
-}
-
-// ResolveGroups returns all groups that a user belongs to, including both
-// explicit groups from the access tree and implicit groups based on character level.
-func (a *Authorizer) ResolveGroups(username string) []string {
-	if err := a.ensureFreshCache(); err != nil {
-		return []string{}
-	}
-
-	// Get explicit groups
-	groups := a.GetExplicitGroups(username)
-	if groups == nil {
-		groups = []string{}
-	}
-
-	// Add implicit groups
-	implicitGroups := a.resolveImplicitGroups(username)
-	if implicitGroups != nil {
-		groups = append(groups, implicitGroups...)
-	}
-
-	return groups
-}
-
-// GetExplicitGroups returns the explicit groups a user belongs to from their access tree
-func (a *Authorizer) GetExplicitGroups(username string) []string {
-	if err := a.ensureFreshCache(); err != nil {
-		return []string{}
-	}
-
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Get user's tree
-	tree, ok := a.trees[username]
-	if !ok || tree == nil {
-		return []string{}
-	}
-
-	// Groups are stored in the tree itself
-	if tree.Groups == nil {
-		return []string{}
-	}
-	return tree.Groups
+	return a.ResolvePermission(username, filepath) >= requiredPerm
 }
 
 // CanRead checks if a user has read permission for a path
@@ -158,33 +53,234 @@ func (a *Authorizer) CanGrant(username string, filepath string) bool {
 	return a.ResolvePermission(username, filepath).CanGrant()
 }
 
-// refreshCache loads fresh data from the source
+// ResolvePermission returns the effective permission for a user on a path.
+// It mirrors access.c _get_access: the user map, the user's group maps, and
+// the default "*" map are walked together, component by component, with the
+// nearest-ancestor "*" carried down as an inherited default. "No rule" (0) and
+// explicit Revoked (-1) both mean no access and are normalized to Revoked.
+func (a *Authorizer) ResolvePermission(username string, filepath string) Permission {
+	if err := a.ensureFreshCache(); err != nil {
+		logging.App.Debug("Cache refresh failed", "user", username, "path", filepath, "error", err)
+		return Revoked
+	}
+
+	a.mu.RLock()
+	accessMap := a.accessMap
+	a.mu.RUnlock()
+	if accessMap == nil {
+		return Revoked
+	}
+
+	groups := a.resolveGroups(accessMap, username)
+	perm := resolveAccess(accessMap, username, groups, splitPath(filepath))
+	if perm < Read {
+		// Undecided (0) and Revoked (-1) both deny.
+		perm = Revoked
+	}
+	logging.App.Debug("Resolved permission", "user", username, "path", filepath, "permission", perm)
+	return perm
+}
+
+// resolveAccess is a direct port of access.c _get_access.
+func resolveAccess(accessMap map[string]interface{}, user string, groups []string, parts []string) Permission {
+	// Collect the ordered list of maps to consider: the user's own map (if
+	// any) first, then group maps, then the default "*" map. The user map is
+	// only ever at index 0.
+	maps := make([]map[string]interface{}, 0, len(groups)+2)
+	if um, ok := accessMap[user].(map[string]interface{}); ok {
+		maps = append(maps, um)
+	}
+	for _, g := range groups {
+		if gm, ok := accessMap[g].(map[string]interface{}); ok {
+			maps = append(maps, gm)
+		}
+	}
+	if dm, ok := accessMap["*"].(map[string]interface{}); ok {
+		maps = append(maps, dm)
+	}
+
+	mapc := len(maps)
+	if mapc == 0 {
+		return Revoked
+	}
+
+	// Per-map descent state and carried default (nearest ancestor "*").
+	cur := make([]map[string]interface{}, mapc)
+	dfls := make([]int, mapc)
+	for j := range maps {
+		cur[j] = maps[j]
+		dfls[j] = starVal(maps[j])
+	}
+
+	// Walk the path. For each component, consult the maps in priority order;
+	// the first map that yields a decided (non-zero) level wins that component
+	// (earlier maps override later maps).
+	j := 0
+	for i, part := range parts {
+		final := i == len(parts)-1
+		for j = 0; j < mapc; j++ {
+			dfls[j] = evalMap(part, cur, j, dfls[j], final)
+			if dfls[j] != 0 {
+				break
+			}
+		}
+		if j >= mapc {
+			j = mapc - 1 // no map decided this component; keep the last
+		}
+	}
+
+	// Ruled access: for /d/<x> and /players/<x>, unless the map at index 0
+	// decided (j == 0 with more than one map), a wizard has full access to
+	// their own directory and everyone has read access to an "open" directory
+	// and its contents.
+	if len(parts) >= 2 && (parts[0] == "d" || parts[0] == "players") && (j != 0 || mapc == 1) {
+		if parts[1] == user {
+			return GrantGrant
+		}
+		if len(parts) >= 3 && parts[2] == "open" {
+			return Read
+		}
+	}
+
+	return Permission(dfls[j])
+}
+
+// evalMap is a direct port of access.c eval_map. It returns the access level
+// for one path component in one map, and updates the map's descent state
+// (cur[idx]) to the matched subtree, or nil once the map is exhausted.
+func evalMap(part string, cur []map[string]interface{}, idx, dfl int, final bool) int {
+	m := cur[idx]
+	if m == nil { // map already exhausted; carry its default
+		return dfl
+	}
+
+	// Start from this node's "*", or the inherited default if it has none.
+	acc := starVal(m)
+	if acc == 0 {
+		acc = dfl
+	}
+
+	v, found := m[part]
+	if !found {
+		cur[idx] = nil // no deeper match in this map
+		return acc
+	}
+
+	sub, isBranch := v.(map[string]interface{})
+	if !isBranch {
+		// Leaf: its value applies to this node and everything below it.
+		cur[idx] = nil
+		return permInt(v)
+	}
+
+	// Branch: decide this component's access, then descend.
+	switch {
+	case dfl == 0:
+		acc = starVal(sub)
+	case final:
+		if d := dotVal(sub); d != 0 {
+			acc = d
+		} else {
+			acc = dfl
+		}
+	default: // not the final component
+		if s := starVal(sub); s != 0 {
+			acc = s
+		} else {
+			acc = dfl
+		}
+	}
+	cur[idx] = sub
+	return acc
+}
+
+// resolveGroups returns the ordered groups for a user: explicit "?" groups (in
+// order) followed by implicit level-based arch groups, matching query_groups.
+func (a *Authorizer) resolveGroups(accessMap map[string]interface{}, username string) []string {
+	groups := explicitGroups(accessMap, username)
+
+	if user, err := a.characterData.LoadUser(username); err == nil {
+		if _, ok := accessMap[GroupArchFull].(map[string]interface{}); ok && user.Level >= users.ARCHWIZARD {
+			groups = append(groups, GroupArchFull)
+		} else if _, ok := accessMap[GroupArchJunior].(map[string]interface{}); ok &&
+			user.Level >= users.JUNIOR_ARCH && user.Level != users.ELDER {
+			groups = append(groups, GroupArchJunior)
+		}
+	}
+	return groups
+}
+
+// ResolveGroups returns all groups a user belongs to (explicit then implicit).
+func (a *Authorizer) ResolveGroups(username string) []string {
+	if err := a.ensureFreshCache(); err != nil {
+		return []string{}
+	}
+	a.mu.RLock()
+	accessMap := a.accessMap
+	a.mu.RUnlock()
+	if accessMap == nil {
+		return []string{}
+	}
+	return a.resolveGroups(accessMap, username)
+}
+
+// GetExplicitGroups returns the explicit "?" groups a user belongs to.
+func (a *Authorizer) GetExplicitGroups(username string) []string {
+	if err := a.ensureFreshCache(); err != nil {
+		return []string{}
+	}
+	a.mu.RLock()
+	accessMap := a.accessMap
+	a.mu.RUnlock()
+	if accessMap == nil {
+		return []string{}
+	}
+	return explicitGroups(accessMap, username)
+}
+
+// explicitGroups reads the user's "?" group list from the access map.
+func explicitGroups(accessMap map[string]interface{}, username string) []string {
+	um, ok := accessMap[username].(map[string]interface{})
+	if !ok {
+		return []string{}
+	}
+	raw, ok := um["?"].([]interface{})
+	if !ok {
+		return []string{}
+	}
+	groups := make([]string, 0, len(raw))
+	for _, g := range raw {
+		if s, ok := g.(string); ok {
+			groups = append(groups, s)
+		}
+	}
+	return groups
+}
+
+// refreshCache loads and validates fresh access data.
 func (a *Authorizer) refreshCache() error {
 	logging.App.Debug("Refreshing access cache")
 	rawData, err := a.source.LoadAccessData()
 	if err != nil {
-		logging.App.Debug("Failed to load access data", "error", err)
 		return fmt.Errorf("loading raw data: %w", err)
 	}
 
-	trees, err := BuildAccessTrees(rawData)
+	accessMap, err := loadAccessMap(rawData)
 	if err != nil {
-		logging.App.Debug("Failed to build access trees", "error", err)
-		return fmt.Errorf("building access trees: %w", err)
+		return fmt.Errorf("loading access map: %w", err)
 	}
 
 	a.mu.Lock()
-	a.trees = trees
+	a.accessMap = accessMap
 	a.lastRefresh = time.Now()
 	a.mu.Unlock()
-
 	return nil
 }
 
-// ensureFreshCache checks if cache needs refresh
+// ensureFreshCache refreshes the cache if the TTL has elapsed.
 func (a *Authorizer) ensureFreshCache() error {
 	a.mu.RLock()
-	needsRefresh := time.Since(a.lastRefresh) >= a.cacheDuration
+	needsRefresh := a.accessMap == nil || time.Since(a.lastRefresh) >= a.cacheDuration
 	a.mu.RUnlock()
 
 	if needsRefresh {
@@ -193,71 +289,33 @@ func (a *Authorizer) ensureFreshCache() error {
 	return nil
 }
 
-// resolveImplicitPermission returns any implicit permissions for a path and user
-func (a *Authorizer) resolveImplicitPermission(username string, parts []string) (Permission, bool) {
-	if len(parts) >= 2 && parts[0] == "players" {
-		if parts[1] == username {
-			return GrantGrant, true // Users always have GRANT_GRANT on their own directory
-		}
-		// Check for open directory at exactly level 3
-		if len(parts) >= 3 && parts[2] == "open" && len(parts) == 3 {
-			return Read, true // Everyone can read open directories at level 3
-		}
+// starVal returns a node's "*" access level (0 if absent).
+func starVal(m map[string]interface{}) int { return permInt(m["*"]) }
+
+// dotVal returns a node's "." access level (0 if absent).
+func dotVal(m map[string]interface{}) int { return permInt(m["."]) }
+
+// permInt coerces a raw access value to an int (0 for absent/unexpected).
+func permInt(v interface{}) int {
+	switch x := v.(type) {
+	case int:
+		return x
+	case float64:
+		return int(x)
+	case Permission:
+		return int(x)
 	}
-	return Revoked, false
+	return 0
 }
 
-// resolveImplicitGroups returns implicit groups based on character level
-func (a *Authorizer) resolveImplicitGroups(username string) []string {
-	user, err := a.characterData.LoadUser(username)
-	if err != nil {
-		return []string{}
-	}
-
-	groups := make([]string, 0)
-
-	// Check if the groups exist in the access map before adding them
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-
-	// Arch_full for archwizards and above
-	if _, ok := a.trees[GroupArchFull]; ok && user.Level >= users.ARCHWIZARD {
-		groups = append(groups, GroupArchFull)
-	} else if _, ok := a.trees[GroupArchJunior]; ok && user.Level >= users.JUNIOR_ARCH && user.Level != users.ELDER {
-		// Arch_junior for junior arches (except elders)
-		groups = append(groups, GroupArchJunior)
-	}
-
-	return groups
-}
-
-// resolveNodePermission recursively checks permissions in a node
-func (a *Authorizer) resolveNodePermission(node *AccessNode, pathParts []string) Permission {
-	if node == nil {
-		return Revoked
-	}
-
-	// At the target node (final node)
-	if len(pathParts) == 0 {
-		// At final node, dot access overrides star access
-		if node.DotAccess != Revoked {
-			return node.DotAccess
+// splitPath cleans a path and returns its components (dropping "" and ".").
+func splitPath(p string) []string {
+	raw := strings.Split(path.Clean(p), "/")
+	parts := make([]string, 0, len(raw))
+	for _, s := range raw {
+		if s != "" && s != "." {
+			parts = append(parts, s)
 		}
-		// No dot access, use star access
-		return node.StarAccess
 	}
-
-	part := pathParts[0]
-	rest := pathParts[1:]
-
-	// Check for exact match in children
-	if child, ok := node.Children[part]; ok {
-		// Recursively check child permissions
-		childPerm := a.resolveNodePermission(child, rest)
-		// If child returns Revoked, that's final - don't fall back to star access
-		return childPerm
-	}
-
-	// No matching child, use star access
-	return node.StarAccess
+	return parts
 }

--- a/pkg/authorization/authorizer_mud_test.go
+++ b/pkg/authorization/authorizer_mud_test.go
@@ -1,0 +1,91 @@
+package authorization
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mmcdole/viking-ftpd/pkg/lpc"
+	"github.com/mmcdole/viking-ftpd/pkg/users"
+)
+
+// loadRealAuthorizer builds an Authorizer over the production access.txt shipped
+// in resources/. That file is the bare access_map mapping, so it is wrapped as
+// an object field before parsing.
+func loadRealAuthorizer(t *testing.T, testUsers map[string]int) *Authorizer {
+	t.Helper()
+	raw, err := os.ReadFile("../../resources/access.txt")
+	if err != nil {
+		t.Skipf("no resources/access.txt: %v", err)
+	}
+	res, err := lpc.NewObjectParser(false).ParseObject("access_map " + strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("parse access.txt: %v", err)
+	}
+
+	usrc := users.NewMemorySource()
+	for name, level := range testUsers {
+		usrc.AddUser(&users.User{Username: name, Level: level, PasswordHash: "x"})
+	}
+	auth := NewAuthorizer(&mockAccessSource{tree: res.Object}, usrc, time.Hour)
+	if err := auth.refreshCache(); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	return auth
+}
+
+// TestRealAccessData asserts specific decisions against the production access
+// map. The cases marked "(was wrong)" are the divergences from the MUD that
+// this change fixes; they resolved differently before the resolver rewrite.
+func TestRealAccessData(t *testing.T) {
+	auth := loadRealAuthorizer(t, map[string]int{
+		"anon":       users.WIZARD,      // no map
+		"dios":       users.WIZARD,      // map: {"*":5, "players":{"gaia":1}}
+		"drake":      users.WIZARD,      // map: {"*":5}
+		"preman":     users.WIZARD,      // map: explicit players/cryzeck/open:3
+		"fullarch":   users.ARCHWIZARD,  // no map, implicit Arch_full ({"*":4})
+		"juniorarch": users.JUNIOR_ARCH, // no map, implicit Arch_junior ({"d":3,"players":3})
+	})
+
+	cases := []testCase{
+		// Read-by-default from the real root "*":1.
+		{"root_readable", "anon", "/", Read},
+		{"tmp_writable", "anon", "/tmp", Write},
+		{"data_private", "anon", "/data", Revoked},
+		{"accounts_private", "anon", "/accounts", Revoked},
+		{"log_readable", "anon", "/log/foo", Read},
+		{"log_driver_private", "anon", "/log/Driver", Revoked},
+
+		// Inherited "*" reaches star-less subtrees (was wrong: Revoked).
+		{"com_readable", "anon", "/com", Read},
+		{"com_a_readable", "anon", "/com/a", Read},
+		{"com_a_law_revoked", "anon", "/com/a/law", Revoked}, // explicit -1
+
+		// Open directories: the dir and its contents are world-readable
+		// (was wrong: contents Revoked).
+		{"open_dir", "anon", "/players/drake/open", Read},
+		{"open_contents", "anon", "/players/drake/open/file.c", Read},
+		{"open_d_domain", "anon", "/d/Foo/open", Read},
+		{"open_d_contents", "anon", "/d/Foo/open/x", Read},
+
+		// Blanket "*" grants reach into subdirectories (was wrong: Revoked).
+		{"wildcard_players", "dios", "/players/knubo", GrantGrant},
+		{"wildcard_deep", "dios", "/players/cryzeck/sms", GrantGrant},
+		{"wildcard_domain", "drake", "/d/Foo/room.c", GrantGrant},
+		{"wildcard_specific", "dios", "/players/gaia", Read}, // dios's explicit players/gaia:1 overrides *:5
+
+		// A user's explicit grant on someone's open dir wins over the implicit
+		// open read (was wrong: downgraded to Read).
+		{"explicit_over_open", "preman", "/players/cryzeck/open", Write},
+
+		// Own directory is full access.
+		{"own_dir", "dios", "/players/dios/workroom.c", GrantGrant},
+
+		// Implicit arch groups grant across the tree.
+		{"fullarch_anywhere", "fullarch", "/players/knubo/secret", GrantWrite},
+		{"juniorarch_players", "juniorarch", "/players/knubo", Write},
+		{"juniorarch_com", "juniorarch", "/com", Read}, // via default "*":1, not the group
+	}
+	runTests(t, auth, cases)
+}

--- a/pkg/authorization/authorizer_test.go
+++ b/pkg/authorization/authorizer_test.go
@@ -205,7 +205,10 @@ func TestProductionExample(t *testing.T) {
 
 	t.Run("DefaultAccess", func(t *testing.T) {
 		cases := []testCase{
-			{"root_access", "anonymous", "/", Read},                    // Everyone can read root directory
+			// Root resolves to the default map's "*" (here Revoked). Real
+			// access.txt uses "*":1 so root is readable — see the real-data
+			// test in authorizer_mud_test.go.
+			{"root_access", "anonymous", "/", Revoked},
 			{"accounts_denied", "anonymous", "/accounts", Revoked},     // Accounts dir is private
 			{"characters_denied", "anonymous", "/characters", Revoked}, // Character data is private
 			{"data_denied", "anonymous", "/data/test", Revoked},        // Data dir is private
@@ -219,8 +222,11 @@ func TestProductionExample(t *testing.T) {
 	t.Run("DomainAccess", func(t *testing.T) {
 		cases := []testCase{
 			// Domain wizard permissions
-			{"realm_write", "wizard1", "/d/MyRealm/room.c", Write},           // Full write in own realm
-			{"shared_realm_root", "wizard1", "/d/SharedRealm", Write},        // Write at shared realm root
+			{"realm_write", "wizard1", "/d/MyRealm/room.c", Write}, // Full write in own realm
+			// wizard1's map has no "*" along this path, so the inherited
+			// default is 0 and the MUD uses the node's "*" (Read), not "."
+			// (Write), even for the directory itself.
+			{"shared_realm_root", "wizard1", "/d/SharedRealm", Read},
 			{"shared_realm_files", "wizard1", "/d/SharedRealm/room.c", Read}, // Only read in shared files
 		}
 		runTests(t, auth, cases)
@@ -240,7 +246,7 @@ func TestCorePermissions(t *testing.T) {
 
 	t.Run("DotVsStar", func(t *testing.T) {
 		cases := []testCase{
-			{"root_dot", "anonymous", "/", Read},               // Root dir is readable
+			{"root_dot", "anonymous", "/", Revoked},            // Root resolves to default "*" (Revoked here); real data uses "*":1
 			{"root_star", "anonymous", "/unknown", Revoked},    // Unknown paths are denied
 			{"public_dot", "anonymous", "/public", Read},       // Can read public dir
 			{"public_star", "anonymous", "/public/file", Read}, // Can read files in public
@@ -288,7 +294,9 @@ func TestCorePermissions(t *testing.T) {
 	t.Run("UserOverrides", func(t *testing.T) {
 		cases := []testCase{
 			{"simple_override", "user", "/override", Write}, // User overrides default Revoked
-			{"special_dot", "user", "/special", Write},      // User-specific dot permission
+			// No inherited default along this path, so "special" itself uses
+			// its "*" (Read), not its "." (Write).
+			{"special_dot", "user", "/special", Read},
 			{"special_star", "user", "/special/file", Read}, // User-specific star permission
 		}
 		runTests(t, auth, cases)
@@ -346,10 +354,11 @@ func TestImplicitPermissions(t *testing.T) {
 			{"wizard-other", "wizard", "/players/arch", Revoked},
 			{"wizard-open", "wizard", "/players/arch/open", Read},
 
-			// Open directory restrictions
-			{"open-subdir", "wizard", "/players/arch/open/subdir", Revoked},
+			// The "open" rule grants read to the open dir AND its contents
+			// (depth >= 3), but only when parts[2] == "open".
+			{"open-subdir", "wizard", "/players/arch/open/subdir", Read},
 			{"not-open", "wizard", "/players/arch/not_open", Revoked},
-			{"deep-open", "wizard", "/players/arch/deep/open", Revoked},
+			{"deep-open", "wizard", "/players/arch/deep/open", Revoked}, // "open" not at parts[2]
 
 			// Home directory trumps group permissions
 			{"home-trumps-group", "arch", "/players/arch/doc.txt", GrantGrant},   // Even with doc group, home dir wins
@@ -370,13 +379,14 @@ func TestImplicitPermissions(t *testing.T) {
 			{"junior-secure", "junior", "/secure", Write},
 			{"junior-domains", "junior", "/domains", GrantWrite},
 
-			// Elder (level 42) should not get junior arch permissions
-			{"elder-root", "elder", "/", Read},
+			// Elder (level 42) should not get junior arch permissions. Root
+			// resolves to the default "*" (Revoked here); real data uses "*":1.
+			{"elder-root", "elder", "/", Revoked},
 			{"elder-secure", "elder", "/secure", Revoked},
 			{"elder-domains", "elder", "/domains", Revoked},
 
 			// Regular wizard (level 31)
-			{"wizard-root", "wizard", "/", Read},
+			{"wizard-root", "wizard", "/", Revoked},
 			{"wizard-secure", "wizard", "/secure", Revoked},
 			{"wizard-domains", "wizard", "/domains", Revoked},
 		}

--- a/pkg/authorization/types.go
+++ b/pkg/authorization/types.go
@@ -39,19 +39,6 @@ func (p Permission) CanGrant() bool {
 	return p >= GrantGrant
 }
 
-// AccessTree represents a node in the access permission tree
-type AccessTree struct {
-	Root   *AccessNode
-	Groups []string
-}
-
-// AccessNode represents a node in the access tree
-type AccessNode struct {
-	DotAccess  Permission
-	StarAccess Permission
-	Children   map[string]*AccessNode
-}
-
 // Group constants
 const (
 	GroupArchFull   = "Arch_full"


### PR DESCRIPTION
The Go resolver doesn't match the MUD's own permission logic (`_get_access` / `eval_map` in `resources/access.c`). I ran the real access map through both and about a quarter of paths come out differently, always with Go denying something the MUD allows, never the other way around.

The root cause is that a `*` wasn't inherited down the tree. In the MUD, a `*` at some level (a user's `{"*":5}`, or the root's `*:1`) covers everything beneath it until a more specific rule takes over. The Go code only looked at the `*` on the exact folder being checked. That's why admins with a blanket `{"*":5}` grant got "permission denied" on their own subdirectories, and why plain read-by-default never reached dirs like `/com`.

While fixing that I lined up two more things with the MUD: the `open` directory rule now grants read to the open dir and everything inside it (and to `/d/<domain>/open`, not just `/players`), and an explicit entry in a user's own map wins over the implicit open/own-dir grants instead of being silently overridden.

The resolver now walks the raw access map the same way the MUD does. That's why `AccessTree` / `AccessNode` / `BuildAccessTrees` are gone: they were internal only, and pre-building a tree threw away the difference between "no rule here" and "explicitly revoked", which is exactly the distinction the correct algorithm needs. Load-time validation stays, in `loadAccessMap`.

I can't run DGD here, so I validated another way. `authorizer_mud_test.go` pins the decisions this fixes against the real `access.txt`, and a differential harness (this resolver against a second, independently written port of `access.c`) agrees on all 297 real paths. The full suite passes under `-race`, including the FTP/SFTP end-to-end tests.

Worth pushing a few paths through the live MUD before merging, since that's the one check I couldn't do from here.

Closes #22
